### PR TITLE
Fix Username Quick Filtering for New URL Format

### DIFF
--- a/src/scripts/content/filter-classes/UsersFilter.class.js
+++ b/src/scripts/content/filter-classes/UsersFilter.class.js
@@ -110,7 +110,7 @@ const UsersFilter = (() => {
                             if (username !== null) {
                                 control = document.createElement('span');
                                 control.classList.add('hide-user-corner');
-                                control.setAttribute('username', match[1]);
+                                control.setAttribute('username', username);
                                 control.addEventListener('click', this.toggleUserDeviationClickHandler);
                                 link.appendChild(control);
                             } else {


### PR DESCRIPTION
This was missed in v5.0.1.

Even though the username seems to be correctly parsed from both the old and the new URL formats now, it wasn't actually being used. This caused the "www" to still be filtered by the quick filter functionality (at least when the new URL format was in use), although that silently failed, since the "www" user is now blacklisted.