### PR TITLE
Use URL Slugs for Deviation Metadata

### DIFF
--- a/src/helpers/constants.js
+++ b/src/helpers/constants.js
@@ -3,6 +3,8 @@ export const URL = {
     'REGEX': /^https ?:\/\/(?:(\S+)\.)?deviantart\.com\/([^\?]*)(?:\?(.*))?/i
 };
 
+export const DEVIATION_SLUG_REGEX = /\/([^\/]+)\/?$/;
+
 export const PLACEHOLDER_CSS = [
     'z-index: 101;',
     'position: absolute;',

--- a/src/scripts/background/metadata.js
+++ b/src/scripts/background/metadata.js
@@ -1,6 +1,6 @@
 import BrowserTabs from './browser-tabs';
 import DeviantArtAPI from '../../helpers/DeviantArtAPI.class';
-import { URL } from '../../helpers/constants';
+import { URL, DEVIATION_SLUG_REGEX as SLUG_REGEX } from '../../helpers/constants';
 import Utils from '../../helpers/utils';
 
 
@@ -206,6 +206,7 @@ const Metadata = (() => {
                             _metadata.push({
                                 'uuid': deviation.deviationid,
                                 'url': deviation.url,
+                                'slug': SLUG_REGEX.exec(deviation.url)[1],
                                 'category_name': deviation.category,
                                 'category_path': deviation.category_path,
                                 'tags': metadata.tags.map(tag => tag.tag_name)

--- a/src/scripts/content/metadata-cache.js
+++ b/src/scripts/content/metadata-cache.js
@@ -4,14 +4,20 @@ const MetadataCache = (() => {
 
     const DB_NAME = 'metadata';
     const DB_STORE_NAME = 'metadata';
-    const DB_VERSION = 1;
-    const DB_KEY_PATH = 'url';
+    const DB_VERSION = 2;
 
     const MetadataDB = new IndexedDatabase(DB_NAME, DB_STORE_NAME, DB_VERSION, (DBDatabase) => {
         console.log('[Content] MetadataDB UpgradeDB Callback', DBDatabase);
 
+        if (DBDatabase.oldVersion < 2) {
+            // prior to version 2, the keyPath for the main object store was "url" (version 2 switched to "slug")
+            // unfortunately, there isn't an easy way to do an "in-place" upgrade,
+            // so just delete the old store completely and start over
+            DBDatabase.deleteObjectStore(DB_STORE_NAME);
+        }
+
         const DBObjectStore = DBDatabase.createObjectStore(DB_STORE_NAME, {
-            'keyPath': DB_KEY_PATH
+            'keyPath': 'slug'
         });
 
         DBObjectStore.createIndex('uuid', 'uuid', {
@@ -26,24 +32,16 @@ const MetadataCache = (() => {
     const MetadataCache = {
 
         /**
-         * Retrieves metadata for the specified thumbs from the IndexedDB
-         * @param {NodeList} thumbs
+         * Retrieves metadata for the specified slugs from the IndexedDB
+         * @param {string[]} slugs
          */
-        'get': function (thumbs) {
-            console.log('[Content] MetadataCache.get()', thumbs);
-
-            const urls = [];
-            thumbs.forEach((thumb) => {
-                const link = thumb.querySelector('a');
-                if (link !== undefined && link !== null) {
-                    urls.push(link.getAttribute('href'));
-                }
-            });
+        'get': function (slugs) {
+            console.log('[Content] MetadataCache.get()', slugs);
 
             return MetadataDB.GetAll().then((cached) => {
                 const metadata = [];
                 cached.forEach((meta) => {
-                    if (urls.indexOf(meta.url) !== -1) {
+                    if (slugs.indexOf(meta.slug) !== -1) {
                         metadata.push(meta);
                     }
                 });


### PR DESCRIPTION
Fixes #48.

This PR adjusts the metadata injection and cache functionality to use the "slug" for a deviation, instead of the full URL, as the unique identifier. This should allow DeviantArt Filter to work with the "new" URL format (which currently seems to be in Beta Testing) even while the API(s) use the "old" URL format.

Note that there is no way to simply "upgrade" the existing IndexedDB for the metadata cache to key on the new `slug` property (instead of the `url` property). Per the [MDN guide on using IndexedDB](https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API/Using_IndexedDB#Updating_the_version_of_the_database):

 > If you need to change an existing object store (e.g., to change the `keyPath`), then you must delete the old object store and create it again with the new options.

As such, previously cached metadata will simply be discarded when users upgrade to the new version of DeviantArt Filter. It may have been possible to export all of the cached metadata, delete the old object store, create a new object store, and then import the cached metadata, but it didn't seem worth the effort, plus that would have almost certainly introduced additional complications and probably would have caused performance issues during that "migration" process.