### PR TITLE
Create User Filter Context Menu

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -356,5 +356,16 @@
         "content": "$1"
       }
     }
+  },
+  "CreateUserFilterFromDeviation_ContextMenuLabel": {
+    "message": "Create Filter for this User"
+  },
+  "CreateUserFilterForUsername_ContextMenuLabel": {
+    "message": "Create User Filter for \"$USERNAME$\"",
+    "placeholders": {
+      "username": {
+        "content": "$1"
+      }
+    }
   }
 }

--- a/app/scripts/background/menus.js
+++ b/app/scripts/background/menus.js
@@ -1,6 +1,6 @@
 import { AddFilter } from "./filters";
 import { SHOW_FILTER_DEVIATION_MODAL } from "../constants/messages";
-import { TAG_URL_REGEX } from "../constants/url";
+import { TAG_URL_REGEX, USER_URL_REGEX } from "../constants/url";
 
 export const MENUS = [
   {
@@ -10,6 +10,17 @@ export const MENUS = [
     ),
     contexts: ["link"],
     targetUrlPatterns: ["*://*.deviantart.com/tag/*"],
+  },
+  {
+    id: "filter-user",
+    title: browser.i18n.getMessage(
+      "CreateUserFilterFromDeviation_ContextMenuLabel"
+    ),
+    contexts: ["link"],
+    targetUrlPatterns: [
+      "*://*.deviantart.com/*/art/*",
+      "*://*.deviantart.com/*/journal/*",
+    ],
   },
   {
     id: "show-filter-modal-deviation",
@@ -60,6 +71,14 @@ export const OnMenuClicked = (info, tab) => {
       }
       break;
 
+    case "filter-user":
+      if (USER_URL_REGEX.test(info.linkUrl)) {
+        // eslint-disable-next-line no-case-declarations
+        const username = USER_URL_REGEX.exec(info.linkUrl)[1];
+        AddFilter("users", { username });
+      }
+      break;
+
     case "show-filter-modal-deviation":
       browser.tabs.sendMessage(tab.id, {
         action: SHOW_FILTER_DEVIATION_MODAL,
@@ -88,6 +107,15 @@ export const OnMenuShown = (info, tab) => {
       title: browser.i18n.getMessage(
         "CreateKeywordFilterForTag_ContextMenuLabel",
         keyword
+      ),
+    });
+  } else if (USER_URL_REGEX.test(info.linkUrl)) {
+    // filter-user menu
+    const username = USER_URL_REGEX.exec(info.linkUrl)[1];
+    UpdateMenuItem("filter-user", {
+      title: browser.i18n.getMessage(
+        "CreateUserFilterForUsername_ContextMenuLabel",
+        username
       ),
     });
   }

--- a/app/scripts/constants/url.js
+++ b/app/scripts/constants/url.js
@@ -25,10 +25,12 @@ export const PAGES = {
 };
 
 export const TAG_URL_REGEX = /\/tag\/([^\/]+)/i;
+export const USER_URL_REGEX = /\/([^\/]+)\/(?:art|journal)/i;
 
 export default {
   WILDCARD,
   REGEX,
   PAGES,
   TAG_URL_REGEX,
+  USER_URL_REGEX,
 };


### PR DESCRIPTION
This PR adds a new context menu to Deviation links to create a User filter for the username in the Deviation's URL.

This closes #148 

![Firefox](https://user-images.githubusercontent.com/5234749/133869500-ec2818e4-97ea-452d-9828-7c44d71c5274.png)
![Chrome](https://user-images.githubusercontent.com/5234749/133869503-917af8c9-aaea-4b31-940d-0f8bcb23cf87.png)


